### PR TITLE
Update Akka version for 2.13 builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import CrossCompilationUtil.{getVersion, scalaVersionMatch}
 organization := "com.pennsieve"
 
 name := "service-utilities"
@@ -17,11 +18,7 @@ scalacOptions ++= Seq(
   "-deprecation",
 )
 
-scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-  case Some((2, 12)) =>
-    Seq("-Xmax-classfile-name", "100", "-Ypartial-unification")
-  case _ => Nil
-})
+scalacOptions ++= scalaVersionMatch(scalaVersion.value, Seq("-Xmax-classfile-name", "100", "-Ypartial-unification"), Nil)
 
 publishTo := {
   val nexus = "https://nexus.pennsieve.cc/repository"
@@ -44,7 +41,6 @@ resolvers ++= Seq(
   "Pennsieve Releases" at "https://nexus.pennsieve.cc/repository/maven-releases",
   "Pennsieve Snapshots" at "https://nexus.pennsieve.cc/repository/maven-snapshots",
   "Flyway" at "https://flywaydb.org/repo",
-  Resolver.bintrayRepo("commercetools", "maven")
 )
 
 credentials += Credentials("Sonatype Nexus Repository Manager",
@@ -53,33 +49,30 @@ credentials += Credentials("Sonatype Nexus Repository Manager",
   sys.env("PENNSIEVE_NEXUS_PW")
 )
 
-lazy val AkkaHttpVersion = "10.1.11"
-lazy val AkkaVersion     = "2.6.5"
+lazy val akkaHttpVersion = SettingKey[String]("akkaHttpVersion")
+akkaHttpVersion := getVersion(scalaVersion.value, "10.1.11", "10.2.9")
+
+lazy val akkaVersion = SettingKey[String]("akkaVersion")
+akkaVersion     := getVersion(scalaVersion.value, "2.6.5", "2.6.19")
 
 lazy val circeVersion    = SettingKey[String]("circeVersion")
-circeVersion := (CrossVersion.partialVersion(scalaVersion.value) match {
-  case Some((2, 12)) => "0.11.1"
-  case _ => "0.14.1"
-})
+circeVersion := getVersion(scalaVersion.value, "0.11.1", "0.14.1")
 
 lazy val LogbackVersion  = "1.2.3"
 
 lazy val akkaHttpCirceVersion = SettingKey[String]("akkaHttpCirceVersion")
-akkaHttpCirceVersion := (CrossVersion.partialVersion(scalaVersion.value) match {
-  case Some((2, 12)) => "1.27.0"
-  case _ => "1.39.2"
-})
+akkaHttpCirceVersion := getVersion(scalaVersion.value, "1.27.0", "1.39.2")
 
 libraryDependencies ++= Seq(
   // --- DB --------------------------------------------------------------------------------------------------------
   "org.flywaydb"                % "flyway-core"              % "4.2.0",
   "org.postgresql"              % "postgresql"               % "42.1.4",
   // --- AKKA ------------------------------------------------------------------------------------------------------
-  "com.typesafe.akka"          %% "akka-http"                % AkkaHttpVersion,
-  "com.typesafe.akka"          %% "akka-stream"              % AkkaVersion,
-  "com.typesafe.akka"          %% "akka-actor"               % AkkaVersion,
+  "com.typesafe.akka"          %% "akka-http"                % akkaHttpVersion.value,
+  "com.typesafe.akka"          %% "akka-stream"              % akkaVersion.value,
+  "com.typesafe.akka"          %% "akka-actor"               % akkaVersion.value,
   // --- Logging ---------------------------------------------------------------------------------------------------
-  "com.typesafe.akka"          %% "akka-slf4j"               % AkkaVersion,
+  "com.typesafe.akka"          %% "akka-slf4j"               % akkaVersion.value,
   "com.typesafe.scala-logging" %% "scala-logging"            % "3.9.2",
   "ch.qos.logback"              % "logback-classic"          % LogbackVersion,
   "ch.qos.logback"              % "logback-core"             % LogbackVersion,

--- a/project/CrossCompilationUtil.scala
+++ b/project/CrossCompilationUtil.scala
@@ -1,0 +1,30 @@
+import sbt.{ CrossVersion, ModuleID }
+
+object CrossCompilationUtil {
+
+  def scalaVersionMatch[T](
+    scalaVersion: String,
+    if212: T,
+    otherwise: T
+  ): T = {
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, 12)) => if212
+      case _ => otherwise
+    }
+  }
+
+  def getVersion(
+    scalaVersion: String,
+    depVersionFor212: String,
+    depVersionFor213: String
+  ): String = {
+    scalaVersionMatch(scalaVersion, depVersionFor212, depVersionFor213)
+  }
+
+  def handle212OnlyDependency(
+    scalaVersion: String,
+    moduleIdFor212: ModuleID
+  ): Seq[ModuleID] = {
+    scalaVersionMatch(scalaVersion, Seq(moduleIdFor212), Nil)
+  }
+}


### PR DESCRIPTION
This fixes the 2.13 builds of this library so that the version of Akka used matches the one used by pennsieve-api.